### PR TITLE
Added utility method calculateXYZListFromBounds().

### DIFF
--- a/test/www/index.html
+++ b/test/www/index.html
@@ -3,7 +3,8 @@
 <head>
     <title>L.TileLayer.Cordova Example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline' http://cdn.leafletjs.com; connect-src 'self'; img-src *; style-src 'self' 'unsafe-inline' http://cdn.leafletjs.com; frame-src 'self' gap:;">
+	
     <script charset="utf-8" src="cordova.js"></script>
 
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
@@ -50,7 +51,9 @@
     <div id="status"></div>
 
     <div id="buttons">
-        <a href="javascript:void(0);" id="test_cache">Cache current extent</a>
+        <a href="javascript:void(0);" id="test_cache_pyramid">Cache current extent (pyramid)</a>
+        &nbsp;&bull;&nbsp;
+        <a href="javascript:void(0);" id="test_cache_bounds">Cache current extent (bounds)</a>
         &nbsp;&bull;&nbsp;
         <a href="javascript:void(0);" id="test_offline">Switch to offline mode</a>
         &nbsp;&bull;&nbsp;

--- a/test/www/index.js
+++ b/test/www/index.js
@@ -35,19 +35,28 @@ function startMap() {
 }
 
 function startButtons() {
-    document.getElementById('test_cache').addEventListener('click', testCaching);
+    document.getElementById('test_cache_pyramid').addEventListener('click', testCachingPyramid);
+    document.getElementById('test_cache_bounds').addEventListener('click', testCachingBounds);
     document.getElementById('test_offline').addEventListener('click', testOffline);
     document.getElementById('test_online').addEventListener('click', testOnline);
     document.getElementById('test_usage').addEventListener('click', testUsage);
     document.getElementById('test_empty').addEventListener('click', testEmpty);
 }
 
-function testCaching() {
+function testCachingPyramid() {
+	testCaching('pyramid');
+}
+
+function testCachingBounds() {
+	testCaching('bounds');
+}
+
+function testCaching(which) {
     var lat       = MAP.getCenter().lat;
     var lng       = MAP.getCenter().lng;
     var zmin      = MAP.getZoom();
     var zmax      = CACHE_ZOOM_MAX;
-    var tile_list = BASE.calculateXYZListFromPyramid(lat, lng, zmin, zmax);
+    var tile_list = (which == 'pyramid' ? BASE.calculateXYZListFromPyramid(lat, lng, zmin, zmax) : BASE.calculateXYZListFromBounds(MAP.getBounds(), zmin, zmax));
     var message   = "Preparing to cache tiles.\n" + "Zoom level " + zmin + " through " + zmax + "\n" + tile_list.length + " tiles total." + "\nClick OK to proceed.";
     var ok        = confirm(message);
     if (! ok) return false;


### PR DESCRIPTION
Added utility method calculateXYZListFromBounds(), which takes a bounds
object (like that obtained by calling MAP.getBounds()), and returns the
list of all tiles required to make up that map area (including multiple
zoom levels, if desired).  Useful for caching an entire view of a map.
Updated test application to show this functionality.  Tested using
Cordova 5.0.0 on Android 4.4.2 and iOS 8.3.  To perform this testing, I
had to update the project's versions of the android and ios platforms,
and install cordova.plugin.whitelist.  None of these environmental
changes are included in this commit; however, I did include a meta tag
in index.html for Content-Security-Policy (to suppress a console warning
from cordova-plugin-whitelist).
