### PR TITLE
Added method getCacheContents() + more

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ In addition, these config options are supported:
 * *name* -- REQUIRED. A unique name for this TileLayer, for naming the tiles and then fetching them later. Keep it brief, e.g. "terrain" See the _Cache Folders and TileLayer Names_ section for more information.
 * *debug* -- If true (defaults to false), extra console.log() calls are made to show progress and debugging.
 
+The constructor and utility function both support an optional success_callback.  This will be called when all time-intensive filesystem activity is complete.  Useful if you want to update a status indicator when the tilelayer has finished initializing.  For example, if you want to call getDiskUsage() immediately in order to display the info to the user, that method should be called within this success_callback.
+
 #Cache Folders and TileLayer Names
 
 *Multiple L.TileLayer.Cordova instances may share the same folder.* Cache management such as emptyCache() and getDiskUsage() are keyed by the folder, so it's important to understand these interactions.
@@ -87,6 +89,13 @@ Set the layer to offline mode. This sets the URL pattern to load tiles from the 
 *goOnline()*
 Set the layer to online mode. This sets the URL pattern to load tiles from the HTTP service indicated in your URL string. On-device offline tiles will no longer be used.
 
+#Methods - Determining State
+*isOnline()*
+Returns true if the map is online, false otherwise.
+
+*isOffline()*
+Returns true if the map is offline, false otherwise.
+
 #Methods - Caching and Calculations
 Much of this is based on the concept of _xyz objects_ An XYZ object is simply a JavaScript object with the attributes _x_, _y_, and _z_ used to describe the ordinates of a tile. Combined with the layer's URL template you provided in the constructor, or with the offline filesystem URL generated internally, an XYZ can be used to cmpose the URL of a specific tile in both offline state and online state.
 
@@ -106,6 +115,9 @@ The _error_callback_ is called in the event of an error. It is passed one parame
 Given a _latitude_ and _longitude_, calculate the tile which contains it. Then, for the (inclusive) range of zoom levels _zmin_ through _zmax_ calculate the pyramid downward.
 The return is a list of _xyz objects_ suitable for use with downloadXYZList()
 
+*calculateXYZListFromBounds(bounds,zmin,zmax)*
+Given a bounds object (like that obtained by calling MAP.getBounds()), return a list of all tiles required to make up that map area (including multiple zoom levels, if specified).
+
 #Methods - Cache Management
 
 See also: Cache Folders and TileLayer Names
@@ -117,3 +129,6 @@ NOTE: This tallies up all tiles in the cache folder, not necessarily those belon
 *emptyCache(done_callback)*
 Delete all of the files in the layer's cache folder. The _done_callback_ is called with two parameters: integer count of the number of files deleted, and integer count of the number of files where deletion failed.
 NOTE: This deletes all tiles in the cache folder, not necessarily those belonging solely to this specific L.TileLayer.Cordova instance. See the section about Cache Folders and TileLayer Names.
+
+*getCacheContents(done_callback)*
+Calls done_callback with an array representing the cache contents.  Useful if you want to build some sort of cache navigator for your UI.

--- a/test/www/index.html
+++ b/test/www/index.html
@@ -51,15 +51,17 @@
     <div id="status"></div>
 
     <div id="buttons">
-        <a href="javascript:void(0);" id="test_cache_pyramid">Cache current extent (pyramid)</a>
+        <a href="javascript:void(0);" id="test_cache_pyramid">Cache current (pyramid)</a>
         &nbsp;&bull;&nbsp;
-        <a href="javascript:void(0);" id="test_cache_bounds">Cache current extent (bounds)</a>
+        <a href="javascript:void(0);" id="test_cache_bounds">Cache current (bounds)</a>
         &nbsp;&bull;&nbsp;
         <a href="javascript:void(0);" id="test_offline">Switch to offline mode</a>
         &nbsp;&bull;&nbsp;
         <a href="javascript:void(0);" id="test_online">Switch to online mode</a>
         &nbsp;&bull;&nbsp;
         <a href="javascript:void(0);" id="test_usage">Show cache usage</a>
+        &nbsp;&bull;&nbsp;
+        <a href="javascript:void(0);" id="test_browse_cache">Browse cache</a>
         &nbsp;&bull;&nbsp;
         <a href="javascript:void(0);" id="test_empty">Clear cache</a>
     </div>

--- a/test/www/index.js
+++ b/test/www/index.js
@@ -23,15 +23,21 @@ function startMap() {
             folder: 'LTileLayerCordovaExample',
             name:   'example',
             debug:   true
-        }).addTo(MAP);
+        }, function() {
+			updateStatus();
+		}).addTo(MAP);
     } catch (e) {
         alert(e);
     }
 
     MAP.setView([LAT,LNG],ZOOM);
     MAP.on('moveend', function () {
-        document.getElementById('status').innerHTML =  MAP.getCenter().lat.toFixed(5) + ' x ' + MAP.getCenter().lng.toFixed(5) + ' @ ' + MAP.getZoom();
+		updateStatus();
     }).fire('moveend');
+}
+
+function updateStatus() {
+	document.getElementById('status').innerHTML =  MAP.getCenter().lat.toFixed(5) + ' x ' + MAP.getCenter().lng.toFixed(5) + ' @ ' + MAP.getZoom() + (BASE.isOnline() ? ' (ONLINE)' : BASE.isOffline() ? ' (OFFLINE)' : '');
 }
 
 function startButtons() {
@@ -40,6 +46,7 @@ function startButtons() {
     document.getElementById('test_offline').addEventListener('click', testOffline);
     document.getElementById('test_online').addEventListener('click', testOnline);
     document.getElementById('test_usage').addEventListener('click', testUsage);
+    document.getElementById('test_browse_cache').addEventListener('click', testBrowseCache);
     document.getElementById('test_empty').addEventListener('click', testEmpty);
 }
 
@@ -90,10 +97,12 @@ function testCaching(which) {
 
 function testOffline() {
     BASE.goOffline();
+	updateStatus();
 }
 
 function testOnline() {
     BASE.goOnline();
+	updateStatus();
 }
 
 function testUsage() {
@@ -102,6 +111,13 @@ function testUsage() {
         var kilobytes = Math.round( bytes / 1024 );
         status_block.innerHTML = "Cache status" + "<br/>" + filecount + " files" + "<br/>" + kilobytes + " kB";
     });
+}
+
+function testBrowseCache() {
+	BASE.getCacheContents(function(cache) {
+		console.log(cache);
+		alert("Look in console for cache contents");
+	});
 }
 
 function testEmpty() {


### PR DESCRIPTION
Added method getCacheContents(), which returns a list of tiles in the
cache; useful if you want to build a cache navigator in your UI.  Added
methods isOnline()/isOffline().  Added optional success_callback to
constructor and utility function, which is called when all
time-intensive filesystem activity is complete; useful for updating
status indicators that rely on filesystem info (like getDiskUsage()).
Added getLng()/getLat(), used by getCacheContents().  Updated doc and
test app.  Tested on Android 4.4.2 and iOS 8.3.
